### PR TITLE
Add SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Stackable",
+    platforms: [
+        .iOS(.v12),
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Stackable",
+            targets: ["Stackable"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Stackable",
+            dependencies: [],
+            path: "Stackable"),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Stackable",
+    name: "RPStackable",
     platforms: [
         .iOS(.v12),
     ],

--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ stack.stackable.add([
 
 <img src="https://github.com/Rightpoint/Stackable/blob/develop/docs/MenuExampleRender.png" height="600">
 
-Stackable is available through [CocoaPods](https://cocoapods.org). To install
-it, simply add the following line to your Podfile:
-
-```ruby
-pod 'RPStackable'
-```
-
 ## Views
 **Stackable** includes built-in support for all `UIView` subclasses.
 
@@ -251,10 +244,12 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Requirements
 
+* iOS 12.0+
+
 ## Installation
 
-Stackable is available through [CocoaPods](https://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+Stackable is available as a Swift Package. You can also install it through 
+[CocoaPods](https://cocoapods.org) by adding the following line to your Podfile:
 
 ```ruby
 pod 'RPStackable'

--- a/Stackable/ScrollingStackView.swift
+++ b/Stackable/ScrollingStackView.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// A `UIStackView` in a `UIScrollView`, whose stackView height will prefer to be at least the size of the frame of the scrollview.
 /// If content grows beyond the frame, will allow for scrolling.

--- a/Stackable/ScrollingStackView.swift
+++ b/Stackable/ScrollingStackView.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 /// A `UIStackView` in a `UIScrollView`, whose stackView height will prefer to be at least the size of the frame of the scrollview.

--- a/Stackable/Stackable+A11y.swift
+++ b/Stackable/Stackable+A11y.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public enum StackableAccessibilityID {
     public static let space = "com.rightpoint.stackable.space"

--- a/Stackable/Stackable+A11y.swift
+++ b/Stackable/Stackable+A11y.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 public enum StackableAccessibilityID {

--- a/Stackable/Stackable+Alignment.swift
+++ b/Stackable/Stackable+Alignment.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// `StackableViewItem` carries information about how to build a source view, as well as any manipulations that need to be performed before being added to a stackView
 public struct StackableViewItem {

--- a/Stackable/Stackable+Alignment.swift
+++ b/Stackable/Stackable+Alignment.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 /// `StackableViewItem` carries information about how to build a source view, as well as any manipulations that need to be performed before being added to a stackView

--- a/Stackable/Stackable+Debug.swift
+++ b/Stackable/Stackable+Debug.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 public extension StackableExtension where ExtendedType == UIStackView {

--- a/Stackable/Stackable+Debug.swift
+++ b/Stackable/Stackable+Debug.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 public extension StackableExtension where ExtendedType == UIStackView {
 

--- a/Stackable/Stackable+Extended.swift
+++ b/Stackable/Stackable+Extended.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 /// Type that acts as a generic extension point for all `StackableExtended` types.

--- a/Stackable/Stackable+Extended.swift
+++ b/Stackable/Stackable+Extended.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Type that acts as a generic extension point for all `StackableExtended` types.
 public class StackableExtension<ExtendedType> {

--- a/Stackable/Stackable+Hairlines.swift
+++ b/Stackable/Stackable+Hairlines.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 /// `StackableHairline` carries information about where to build a hairline, as well as any manipulations that need to be performed before being added to a stackView.

--- a/Stackable/Stackable+Hairlines.swift
+++ b/Stackable/Stackable+Hairlines.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// `StackableHairline` carries information about where to build a hairline, as well as any manipulations that need to be performed before being added to a stackView.
 public struct StackableHairline {

--- a/Stackable/Stackable+Spacing.swift
+++ b/Stackable/Stackable+Spacing.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 // MARK: - Stackable Spaces

--- a/Stackable/Stackable+Spacing.swift
+++ b/Stackable/Stackable+Spacing.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 // MARK: - Stackable Spaces
 

--- a/Stackable/Stackable+Views.swift
+++ b/Stackable/Stackable+Views.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 // MARK: - StackableView Conformance

--- a/Stackable/Stackable+Views.swift
+++ b/Stackable/Stackable+Views.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 // MARK: - StackableView Conformance
 extension UIView: StackableView {

--- a/Stackable/Support/AlignmentView.swift
+++ b/Stackable/Support/AlignmentView.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 /// Options to specify how a view adjusts its content when its size is different than its intrinsic value.

--- a/Stackable/Support/AlignmentView.swift
+++ b/Stackable/Support/AlignmentView.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Options to specify how a view adjusts its content when its size is different than its intrinsic value.
 public struct StackableAlignment: OptionSet {

--- a/Stackable/Support/UIView+BindVisible.swift
+++ b/Stackable/Support/UIView+BindVisible.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 // MARK: Bind Visible
 // Use this pattern to monitor `.isHidden` of some other view, and update `self.isHidden` to match.

--- a/Stackable/Support/UIView+BindVisible.swift
+++ b/Stackable/Support/UIView+BindVisible.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 // MARK: Bind Visible

--- a/Stackable/Support/Utilities.swift
+++ b/Stackable/Support/Utilities.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 internal extension UIView {
 

--- a/Stackable/Support/Utilities.swift
+++ b/Stackable/Support/Utilities.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 internal extension UIView {

--- a/Stackable/UIStackView+Utilities.swift
+++ b/Stackable/UIStackView+Utilities.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Rightpoint. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 // MARK: - UIStackView Utilities

--- a/Stackable/UIStackView+Utilities.swift
+++ b/Stackable/UIStackView+Utilities.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 // MARK: - UIStackView Utilities
 extension StackableExtension where ExtendedType == UIStackView {


### PR DESCRIPTION
This PR adds support for Swift Package Manager (and closes #27).

I added explicit UIKit imports to all source files that needed it. It wasn't a problem in Cocoapods, but when imported through SPM, the individual source files need to import UIKit or the compiler will fail.